### PR TITLE
Fix typo prometheus_scraper_interface param

### DIFF
--- a/source/configuration/networks.rst
+++ b/source/configuration/networks.rst
@@ -87,7 +87,7 @@ at ``environments/monitorning/configuration.yml``.
    ##########################
    # monitoring
 
-   prometheus_scaper_interface: eth1
+   prometheus_scraper_interface: eth1
 
 Tunnel
 ======


### PR DESCRIPTION
I didn't read it carefully in the beginning and was a bit astonished why Ansible was complaining.