### PR TITLE
Fix neutron external interface names

### DIFF
--- a/source/configuration/environments/openstack/neutron.rst
+++ b/source/configuration/environments/openstack/neutron.rst
@@ -72,7 +72,7 @@ VLAN interfaces as flat provider networks
 .. code-block:: yaml
 
    neutron_bridge_name: [...],br-vlan100,br-vlan200
-   neutron_external_interface: [...],br-vlan100,br-vlan200
+   neutron_external_interface: [...],vlan100,vlan200
 
 .. warning::
 


### PR DESCRIPTION
  'neutron_external_interface' need to be set to network interface names not
   bridge names.