### PR TITLE
Set Octavia ssh-key name to Kolla standard

### DIFF
--- a/source/deployment/services/loadbalancer.rst
+++ b/source/deployment/services/loadbalancer.rst
@@ -116,7 +116,7 @@ Create keypair for starting amphora instances
 
 .. code-block:: console
 
-   openstack --os-cloud octavia keypair create octavia
+   openstack --os-cloud octavia keypair create octavia_ssh_key
 
 Create flavor for amphora instances
 -----------------------------------


### PR DESCRIPTION
  Kolla uses as default name `octavia_ssh_key`

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>