### PR TITLE
Change docs.osism.de/io to docs.osism.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSISM documentation
 
-Published at http://docs.osism.de.
+Published at http://docs.osism.tech.
 
 ## Install dependencies for building documentation
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,7 +20,7 @@ html_show_copyright = True
 htmlhelp_basename = 'documentation'
 html_theme_options = {
     'display_version': False,
-    'canonical_url': 'https://docs.osism.de/',
+    'canonical_url': 'https://docs.osism.tech/',
     'style_external_links': True,
     'logo_only': True,
     'prev_next_buttons_location': None

--- a/source/index.rst
+++ b/source/index.rst
@@ -10,7 +10,7 @@ Further details about OSISM can be found on https://www.osism.tech. Do not hesit
 to write an e-mail to info@osism.tech if you have questions or doubts.
 
 A testbed of OSISM is available under https://github.com/osism/testbed.
-Documentation is available at https://docs.osism.de/testbed. This
+Documentation is available at https://docs.osism.tech/testbed. This
 allows you to deploy a small environment with four nodes on a public cloud like our
 `Betacloud <https://www.betacloud.de>`_. Other providers like Citycloud are also
 supported.

--- a/source/overview/cli-reference.rst
+++ b/source/overview/cli-reference.rst
@@ -277,7 +277,7 @@ configuration directory environments/custom , environments/proxmox
    proxmox
        manage proxmox role
    custom force-timesync
-       force NTP sync via chrony http://docs.osism.io/operations/generic.html#run-commands
+       force NTP sync via chrony http://docs.osism.tech/operations/generic.html#run-commands
    custom personalized-accounts
        runs playbook for configuring personalized accounts
 


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>