### PR TITLE
Use https://docs.osism.tech instead of http://docs.osism.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSISM documentation
 
-Published at http://docs.osism.tech.
+Published at https://docs.osism.tech.
 
 ## Install dependencies for building documentation
 

--- a/source/overview/cli-reference.rst
+++ b/source/overview/cli-reference.rst
@@ -277,7 +277,7 @@ configuration directory environments/custom , environments/proxmox
    proxmox
        manage proxmox role
    custom force-timesync
-       force NTP sync via chrony http://docs.osism.tech/operations/generic.html#run-commands
+       force NTP sync via chrony https://docs.osism.tech/operations/generic.html#run-commands
    custom personalized-accounts
        runs playbook for configuring personalized accounts
 


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>