### PR TITLE
Monitoring: Add listen address to Grafana configuration

### DIFF
--- a/source/deployment/services/monitoring.rst
+++ b/source/deployment/services/monitoring.rst
@@ -33,6 +33,9 @@ Prepare configuration repository
 
 .. code-block:: yaml
 
+   [server]
+   http_addr = {{ internal_address }}
+
    [alerting]
    enabled = false
 


### PR DESCRIPTION
Grafana by default binds to all interfaces. This will fail when haproxy
has already been deployed with Grafana enabled.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>