### PR TITLE
documentation: grub cmdline iommu

### DIFF
--- a/source/configuration/environments/generic/grub.rst
+++ b/source/configuration/environments/generic/grub.rst
@@ -45,7 +45,7 @@ Disable predictable network interface names
 Enable IOMMU
 ============
 
-Intel 
+Intel
 -----
 
 .. code-block:: yaml
@@ -55,24 +55,22 @@ Intel
 
     grub__default_configuration:
       - name: 'cmdline_linux_default'
-        value:
-          - intel_iommu=on
-          - iommu=pt
-
+          value:
+            - intel_iommu=on
+            - iommu=pt
 
 AMD
 ---
 
 .. code-block:: yaml
 
+   ##########################
    # grub
 
-     grub__default_configuration:
-       - name: 'cmdline_linux_default'
-         value:
-           - iommu=pt
-
-
+    grub__default_configuration:
+      - name: 'cmdline_linux_default'
+          value:
+            - iommu=pt
 
 Support of Docker capabilities
 ==============================

--- a/source/configuration/environments/generic/grub.rst
+++ b/source/configuration/environments/generic/grub.rst
@@ -45,7 +45,7 @@ Disable predictable network interface names
 Enable IOMMU
 ============
 
-Intel
+Intel 
 -----
 
 .. code-block:: yaml
@@ -53,24 +53,26 @@ Intel
    ##########################
    # grub
 
-   grub__default_configuration:
-     - name: 'cmdline_linux_default'
-         value:
-           - intel_iommu=on
+    grub__default_configuration:
+      - name: 'cmdline_linux_default'
+        value:
+          - intel_iommu=on
+          - iommu=pt
+
 
 AMD
 ---
 
 .. code-block:: yaml
 
-   ##########################
    # grub
 
-   grub__default_configuration:
-     - name: 'cmdline_linux_default'
+     grub__default_configuration:
+       - name: 'cmdline_linux_default'
          value:
            - iommu=pt
-           - iommu=1
+
+
 
 Support of Docker capabilities
 ==============================

--- a/source/configuration/environments/generic/grub.rst
+++ b/source/configuration/environments/generic/grub.rst
@@ -53,11 +53,11 @@ Intel
    ##########################
    # grub
 
-    grub__default_configuration:
-      - name: 'cmdline_linux_default'
-          value:
-            - intel_iommu=on
-            - iommu=pt
+   grub__default_configuration:
+     - name: 'cmdline_linux_default'
+         value:
+           - intel_iommu=on
+           - iommu=pt
 
 AMD
 ---
@@ -67,10 +67,10 @@ AMD
    ##########################
    # grub
 
-    grub__default_configuration:
-      - name: 'cmdline_linux_default'
-          value:
-            - iommu=pt
+   grub__default_configuration:
+     - name: 'cmdline_linux_default'
+         value:
+           - iommu=pt
 
 Support of Docker capabilities
 ==============================


### PR DESCRIPTION
for Intel systems you will need:

          - intel_iommu=on
          - iommu=pt

for amd will need only:

          - iommu=pt

because iommu is with amd_iommu already enabled by default

https://www.kernel.org/doc/html/v5.4/admin-guide/kernel-parameters.html
(5.4 it represent ubuntu focal 20.04, it latest it is the same)

Signed-off-by: Mathias Fechner <fechner@osism.tech>