### PR TITLE
Ansible style guide: Add that tasks always must have names

### DIFF
--- a/source/development/ansible-style-guide.rst
+++ b/source/development/ansible-style-guide.rst
@@ -8,6 +8,7 @@ can be found in the Ansible Lint documentation: https://ansible-lint.readthedocs
 Task naming
 ===========
 
+* Tasks must always have names. The only exception allowed is for forked playbooks.
 * A name never starts with a small letter
 * Names are written in present tense
 * No punctuation is used in names


### PR DESCRIPTION
- Add that tasks always must have names.
- This closes #371

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
