### PR TITLE
Fix two typos in appendix configuration.rst

### DIFF
--- a/source/appendix/configuartion.rst
+++ b/source/appendix/configuartion.rst
@@ -11,8 +11,8 @@ Some examples are from firm of production environments.
 Fluentd Authentication
 ============
 
-If fluentd is needed to commuincate with elasticsearch authenticated or it shall
-to interact with a company independ elasticsearch, you are able to configure it
+If fluentd is needed to communicate with elasticsearch authenticated or it shall
+to interact with a company independent elasticsearch, you are able to configure it
 with following configuration parameters:
 
 .. code-block:: console


### PR DESCRIPTION
Fix two speliing issues  in appendix configuration.rst file

Signed-off-by: Mathias Fechner <fechner@osism.tech>