### PR TITLE
approximately is abbreviated as approx. not aprox.

### DIFF
--- a/source/test/benchmark/ceph.rst
+++ b/source/test/benchmark/ceph.rst
@@ -93,4 +93,4 @@ When using bench-fio from https://github.com/louwrentius/fio-plot from within an
 
    $ ./bench_fio --target /testfile --type file --mode randread randwrite --output FIO_OUT --size 6g --block-size 1k 2k 4k 8k 16k 32k 64k 128k
 
-be aware that this scenario takes several hours (aprox. 12) to complete
+be aware that this scenario takes several hours (approx. 12) to complete


### PR DESCRIPTION
See: https://www.collinsdictionary.com/dictionary/english/approx

Signed-off-by: Felix Kronlage-Dammers <fkr@hazardous.org>