### PR TITLE
Change filter label for "Remove old Docker images"

### DIFF
--- a/source/upgrade/kolla.rst
+++ b/source/upgrade/kolla.rst
@@ -181,10 +181,10 @@ Verify none of the old images is running anymore.
 
 .. code-block:: console
 
-   docker ps --filter=label=io.osism.openstack=queens
+   docker ps --filter=label=de.osism.release.openstack=victoria
 
 Remove old version images.
 
 .. code-block:: console
 
-   docker rmi $(docker image ls --quiet --filter=label=io.osism.openstack=queens)
+   docker rmi $(docker image ls --quiet --filter=label=de.osism.release.openstack=victoria)


### PR DESCRIPTION
Old docker filter label "docker ps --filter=label=io.osism.openstack=queens" don't work.

I'll change this to "docker ps --filter=label=kolla_version=victoria"