### PR TITLE
provisioning: use ubuntu 22.04 & remove pressed stuff

### DIFF
--- a/source/overview/requirements.rst
+++ b/source/overview/requirements.rst
@@ -12,7 +12,8 @@ Necessary basic knowledge
 Operating system
 ================
 
-Deployment is supported on Ubuntu 20.04. Other distributions are currently not supported.
+Deployment is supported on Ubuntu 20.04 and 22.04. Other distributions are currently not
+supported.
 
 Deployment
 ==========


### PR DESCRIPTION
* We use Ubuntu 22.04 by default, accordingly use it everywhere
* Add note that the manual installation instructions are for Ubuntu 20.04 (will be revised soon).
* Remove everything to Preseed and only point to the osism/node-image repository

Closes osism/documentation#447

Signed-off-by: Christian Berendt <berendt@osism.tech>