### PR TITLE
Change theme from rtd to material

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -14,17 +14,17 @@ language = 'en'
 exclude_patterns = []
 pygments_style = 'sphinx'
 todo_include_todos = True
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_material'
 html_show_sphinx = False
 html_show_sourcelink = False
 html_show_copyright = True
 htmlhelp_basename = 'documentation'
 html_theme_options = {
-    'display_version': False,
-    'canonical_url': 'https://docs.osism.tech/',
-    'style_external_links': True,
-    'logo_only': True,
-    'prev_next_buttons_location': None
+    "nav_title": "OSISM Documentation",
+    "color_primary": "blue",
+    "color_accent": "light-blue",
+    "globaltoc_depth": 3,
+    "globaltoc_collapse": True,
 }
 html_context = {
     'display_github': True,
@@ -34,6 +34,10 @@ html_context = {
     'conf_py_path': '/source/'
 }
 html_logo = 'images/logo.png'
+html_title = "OSISM Documentation"
+html_sidebars = {
+    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
+}
 #html_static_path = [
 #    '_static'
 #]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 PyGitHub
 Sphinx
-sphinx-rtd-theme
+sphinx-material
 sphinx_fontawesome
 sphinxcontrib-blockdiag
 sphinxcontrib-nwdiag


### PR DESCRIPTION
* RTD theme looks broken with Sphinx 6
* We use the Material theme in all other repositories with Sphinx

Signed-off-by: Christian Berendt <berendt@osism.tech>