### PR TITLE
deployment: use osism instead of ubuntu as install user

### DIFF
--- a/source/deployment/bootstrap.rst
+++ b/source/deployment/bootstrap.rst
@@ -11,21 +11,21 @@ add a new node to an existing environment.
 
   .. code-block:: console
 
-     osism apply operator -u ubuntu
+     osism apply operator -u osism
 
   * The operator key has to be added in advance on all nodes to ``authorized_keys`` of the user
     specified with ``-u``.
   * Alternatively (not recommended), the password can be stored in plain text in a file
-    ``/opt/configuration/secrets/ubuntu_password``. The parameter
-    ``--conn-pass-file /opt/configuration/secrets/ubuntu_password`` must then
+    ``/opt/configuration/secrets/osism_password``. The parameter
+    ``--conn-pass-file /opt/configuration/secrets/osism_password`` must then
     also be specified:
 
     .. code-block:: console
 
-       osism apply operator -u ubuntu --conn-pass-file /opt/configuration/secrets/ubuntu_password
+       osism apply operator -u osism --conn-pass-file /opt/configuration/secrets/osism_password
 
   * If the error ``/bin/sh: 1: /usr/bin/python: not found`` occurs, Python must first be installed
-    with ``osism apply python3 -u ubuntu``.
+    with ``osism apply python3 -u osism``.
 
 * Configuration of the network
 

--- a/source/deployment/manager.rst
+++ b/source/deployment/manager.rst
@@ -54,7 +54,7 @@ this user.
 
 .. code-block:: console
 
-   ANSIBLE_USER=ubuntu ./run.sh operator
+   ANSIBLE_USER=osism ./run.sh operator
 
 * If a password is required to login to the manager node,
   ``ANSIBLE_ASK_PASS=True`` must be set.
@@ -71,7 +71,7 @@ this user.
 
   .. code-block:: console
 
-     ANSIBLE_USER=ubuntu ./run.sh python3
+     ANSIBLE_USER=osism ./run.sh python3
 
 * To verify the creation of the operator user, use the private key file
   ``id_rsa.operator``. Make sure you purge all keys from ssh-agent identity
@@ -107,7 +107,7 @@ this user.
      ANSIBLE_BECOME_ASK_PASS=True \
      ANSIBLE_ASK_VAULT_PASS=True \
      ANSIBLE_ASK_PASS=True \
-     ANSIBLE_USER=ubuntu \
+     ANSIBLE_USER=osism \
      ./run.sh operator
 
 Configuration of the network

--- a/source/deployment/provisioning.rst
+++ b/source/deployment/provisioning.rst
@@ -56,8 +56,8 @@ installation is possible without network connectivity.
   * Adapt the host name accordingly as you need it yourself. ``node`` is only an
     example.
 
-* Set ``ubuntu`` as full name for the new user
-* Set ``ubuntu`` as the username for the account
+* Set ``osism`` as full name for the new user
+* Set ``osism`` as the username for the account
 
   * The later used operator user ``dragon`` is created during the bootstrap
     and should not be created during the installation.
@@ -185,11 +185,11 @@ Step by step of manual installation with screenshots.
 
   .. image:: /images/manual-installation/10-hostname.png
 
-* Full name of User, ``ubuntu``
+* Full name of User, ``osism``
 
   .. image:: /images/manual-installation/11-username-full.png
 
-* username ``ubuntu``
+* username ``osism``
 
   .. image:: /images/manual-installation/12-username.png
 


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>