### PR TITLE
Remove the monitoring network

### DIFF
--- a/source/overview/networks.rst
+++ b/source/overview/networks.rst
@@ -58,8 +58,3 @@ Networks
      - 9000
      - |times|
      - |times|
-   * - Monitoring
-     - all nodes
-     - 1500
-     - |check|
-     - |times|


### PR DESCRIPTION
This is a leftover from Zabbix. The Prometheus and Netdata all run over the internal network.

Signed-off-by: Christian Berendt <berendt@osism.tech>